### PR TITLE
fix: 修复 enzyme 设置文件中 import 语法在项目中无法识别的问题

### DIFF
--- a/configs/jestSetup.js
+++ b/configs/jestSetup.js
@@ -1,4 +1,4 @@
-import Enzyme from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+const Enzyme = require('enzyme')
+const Adapter = require('enzyme-adapter-react-16')
 
 Enzyme.configure({ adapter: new Adapter() })


### PR DESCRIPTION
替换 import 为 require

close #5